### PR TITLE
add support for one level of nested properties

### DIFF
--- a/AutoMapper.Data/ReflectionExtensions.cs
+++ b/AutoMapper.Data/ReflectionExtensions.cs
@@ -22,5 +22,14 @@
             return type.IsGenericType;
 #endif
         }
+
+        public static bool IsValueType(this Type type)
+        {
+#if DOTNET
+            return type.GetTypeInfo().IsValueType;
+#else
+            return type.IsValueType;
+#endif
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for one level of nesting properties. A test has been added to demonstrate that it works.

The convention to accomplish this is to name the column "[Inner.Descr]" would set the 'Descr' property on the 'Inner' property of the root object.

Ex DTO:
```csharp
public class InnerObject
{
    public string Descr { get; set; }
}
public class RootObject
{
    public InnerObject Inner { get; set; }
}
```
Sql:
```sql
select 'Hello World' [Inner.Descr]
```
Result:
```csharp
var dto = Mapper.Map<IDataReader, RootObject>(dataReader);
dto.Inner.Descr.Dump();
-- dto.Inner.Descr = "Hello World"
```
