### PR TITLE
Bumped minimum version for automapper package reference

### DIFF
--- a/AutoMapper.Data/AutoMapper.Data.csproj
+++ b/AutoMapper.Data/AutoMapper.Data.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="[12.0.0, 13.0.0)" />
+    <PackageReference Include="AutoMapper" Version="[13.0.1,)" />
     <None Include="..\README.md" Pack="true" PackagePath="" />
    </ItemGroup>
 

--- a/AutoMapper.Data/AutoMapper.Data.csproj
+++ b/AutoMapper.Data/AutoMapper.Data.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>7.0.2</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Jimmy Bogard</Authors>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Data</AssemblyName>
     <PackageId>AutoMapper.Data</PackageId>
     <PackageTags>AutoMapper</PackageTags>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="[13.0.1,)" />
+    <PackageReference Include="AutoMapper" Version="[13.0.0, 14.0.0)" />
     <None Include="..\README.md" Pack="true" PackagePath="" />
    </ItemGroup>
 


### PR DESCRIPTION
Bumped the minimum version for the AutoMapper package reference to accommodate for the AutoMapper package version updates to v13.0.1  

This should allow a project that uses both the AutoMapper and AutoMapper.Data projects to be compatible with each other  